### PR TITLE
Prevent an error when parameters are passed which aren't used in the query

### DIFF
--- a/src/Sql.php
+++ b/src/Sql.php
@@ -815,6 +815,9 @@ class Sql
         foreach ($params as $val) {
 
             $pos = strpos($tmpQuery, "?");
+            if ($pos === false) {
+                continue;
+            }
 
             $newQuery .= substr($tmpQuery, 0, $pos);
             $tmpQuery = substr($tmpQuery, $pos + 1);


### PR DESCRIPTION
When a parameters array was passed, but was not used by the query the class was prepending a `?` to the query for each element in the parameters array. 
