### PR TITLE
Added getArrayOfColumn function

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -282,6 +282,25 @@ class Result extends AbstractResult
 
 
     /**
+     * Get an array containing only the specified column for each row.
+     *
+     * @param string $column The column to retrieve.
+     *
+     * @return array
+     */
+    public function getArrayOfColumn($column)
+    {
+        $result = iterator_to_array($this->result);
+
+        if (!is_array($result)) {
+            throw new \RuntimeException("Could not retrieve array from iterator");
+        }
+
+        return array_column($result, $column);
+    }
+
+
+    /**
      * Free the memory used by the result resource
      *
      * @return void


### PR DESCRIPTION
These are useful when you only care about one particular field in the result set.

Example use case:
You have an table of companies:

company | name
--- | ---
MR | Test Company
ZR   | Test Company


And you want to check if the current company in your application is in this list of tables, if you do a query such as:
```sql
SELECT * FROM {companies}
```

You will get something like:
```php
[
    [0] => [
        "company"   =>  "MR",
        "name"      =>  "Test Company",
    ],
    [1] => [
        "company"   =>  "ZR",
        "name"      =>  "Test Company",
    ],
],
```

So you would have to deal with the extra level in the result set.

With this change you can simply do this:

```php
$sql = Sql::getInstance();

$query = "SELECT * FROM {companies}";

$result = $sql->query($query);

$companies = $result->getArrayOfColumn("company");
```

This will return an array just containing the values of the "company" field. 

In this case:

```php
[
    [0] =>  "MR",
    [1] =>  "ZR",
],
```

Then you can do:
```php
$currentCompany = "ZR";

if (in_array($currentCompany, $companies)) {
    # Do something interesting
}
```