### PR TITLE
Keep connection status in sync after disconnect

### DIFF
--- a/src/Sql.php
+++ b/src/Sql.php
@@ -2209,6 +2209,10 @@ class Sql
                 break;
         }
 
+        // If the disconnect was successful, set class property to reflect it
+        if($result != false)
+            $this->connected = false;
+
         return $result;
     }
 


### PR DESCRIPTION
Once the disconnect command is called, this allows calling the
constructor again to connect to a different database or refresh the
connection of a long running process.

In particular I noticed this problem when using the database connection with a dependency injector and supervisor as a long running process.